### PR TITLE
Update browse-js.html

### DIFF
--- a/_includes/js/browse-js.html
+++ b/_includes/js/browse-js.html
@@ -12,7 +12,7 @@
 /* add items */
 var items = [
     {% for i in items %}
-    { "title":{{ i.title | strip | jsonify }}, "format":{% if i.format %}{{ i.format | jsonify }}{% else %}""{% endif %}, {% for f in fields %}{% if i[f.field] %}{{ f.field | jsonify }}:{{ i[f.field] | strip | jsonify }},{% endif %}{% endfor %} {% if i.youtubeid %} "youtube": {{ i.youtubeid | jsonify }}, {% endif %}{% if  i.filename contains '/' %}"filename": "{{ i.filename }}" {% else %}"filename":"{{ '/objects/' | relative_url | append: i.filename }}"{% endif %}, "link": "{% if i.parentid %}{{ i.parentid }}#{{ i.objectid }}{% else %}{{ i.objectid }}{% endif %}", "id":{{ i.objectid | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %}
+    { "title":{{ i.title | strip | jsonify }}, "image_small":{% if i.image_small %}{{ i.image_small | jsonify }}{% else %}""{% endif %}, "format":{% if i.format %}{{ i.format | jsonify }}{% else %}""{% endif %}, {% for f in fields %}{% if i[f.field] %}{{ f.field | jsonify }}:{{ i[f.field] | strip | jsonify }},{% endif %}{% endfor %} {% if i.youtubeid %} "youtube": {{ i.youtubeid | jsonify }}, {% endif %} {% if  i.filename contains '/' %}"filename": "{{ i.filename }}" {% else %}"filename":"{{ '/objects/' | relative_url | append: i.filename }}"{% endif %}, "link": "{% if i.parentid %}{{ i.parentid }}#{{ i.objectid }}{% else %}{{ i.objectid }}{% endif %}", "id":{{ i.objectid | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %}
 ];
 
 /* function to create cards for each item */ 
@@ -31,7 +31,7 @@ function makeCard(obj) {
     } else if (obj.format.includes("video")) {
         thumbSrc = '{{ "/assets/lib/icons/" | relative_url }}{{ icons.icon-video }}.svg';  
     } else if (obj.format.includes("pdf")) {
-        thumbSrc = '{{ {{ obj.image_small }} | prepend: relative_url }}';
+        thumbSrc = 'https://gorka350.github.io/PF/' + obj.image_small;
     } else if (obj.format.includes("record")) {
         thumbSrc = '{{ "/assets/lib/icons/" | relative_url }}{{ icons.icon-record }}.svg';
     } else if (obj.format.includes("compound")) {


### PR DESCRIPTION
Hi Gorka,

The changes I am pushing work (hooray!) in my copy of your repository, so hopefully this works for you! If not, let me know and I can go back in and try again. Just click the green button below and wait.

To explain what needed to be edited, the line we were editing during co-working needs to include the url for your GitHub pages site (relative url) and then the image_small liquid object (obj.image_small) from your metadata for each object. The tricky thing was that the computer didn't understand what we meant by `obj.image_small`, which is why nothing was showing up. This error is because the Liquid objects in CollectionBuilder's browse script are defined as `obj` instead of `object`, which means I needed to edit the JavaScript function that assigns the names to those objects too. Happy to explain this further (and maybe in plainer language) on Wednesday!

Best wishes,
Kiran